### PR TITLE
Common configuration approach and branch removed

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ docker-compose run cf_builder
 
 2. build the micro-ROS firmware inside the Docker:
 ```bash
+ros2 run micro_ros_setup configure_firmware.sh crazyflie_position_publisher
 ros2 run micro_ros_setup build_firmware.sh
 ```
 

--- a/dockerfile/builder/Dockerfile
+++ b/dockerfile/builder/Dockerfile
@@ -4,7 +4,7 @@
 FROM ros:dashing
 RUN mkdir -p uros_ws
 WORKDIR uros_ws
-RUN git clone --depth 1 -b feature/mempools_refactor https://github.com/micro-ROS/micro-ros-build.git src/micro-ros-build \
+RUN git clone --depth 1 -b https://github.com/micro-ROS/micro-ros-build.git src/micro-ros-build \
 &&  . /opt/ros/$ROS_DISTRO/setup.sh \
 &&  apt update \
 &&  apt install ed \

--- a/dockerfile/builder/Dockerfile
+++ b/dockerfile/builder/Dockerfile
@@ -1,18 +1,4 @@
-#FROM microros/base:dashing
-
-# TODO: remove when feature/mempools_refactor is merged.
-FROM ros:dashing
-RUN mkdir -p uros_ws
-WORKDIR uros_ws
-RUN git clone --depth 1 -b https://github.com/micro-ROS/micro-ros-build.git src/micro-ros-build \
-&&  . /opt/ros/$ROS_DISTRO/setup.sh \
-&&  apt update \
-&&  apt install ed \
-&&  rosdep update \
-&&  rosdep install --from-paths src --ignore-src -y \
-&&  colcon build \
-&&  rm -rf log/ build/ src/* \
-&&  rm -rf /var/lib/apt/list/*
+FROM microros/base:dashing
 
 RUN . /opt/ros/$ROS_DISTRO/setup.sh \
 &&  . ./install/setup.sh \


### PR DESCRIPTION
Merge after:    
- [x] https://github.com/micro-ROS/micro-ros-build/pull/80
- [x] https://github.com/micro-ROS/rmw-microxrcedds/pull/48
- [x] https://github.com/micro-ROS/rmw-microxrcedds/pull/54


Remove when merged: 
- [ ] https://github.com/micro-ROS/micro-ros-build/tree/feature/mempools_refactor
- [x] https://github.com/micro-ROS/crazyflie_extensions (WARNING: Micro-XRCE-DDS sample app to eProsima?)
- [ ] https://github.com/micro-ROS/micro-ros-build/tree/crazyflie_demo (WARNING: Related to https://micro-ros.github.io/docs/tutorials/demos/crazyflie_demo/)

To check:
- https://github.com/micro-ROS/micro-ros-build/commits/feature/tof_sensor: Maybe a rename needed