### PR TITLE
update nodejs version

### DIFF
--- a/dockerfile/visualizer/Dockerfile
+++ b/dockerfile/visualizer/Dockerfile
@@ -14,11 +14,16 @@ RUN groupadd --gid $USER_GID $USERNAME && \
     echo $USERNAME ALL=\(root\) NOPASSWD:ALL > /etc/sudoers.d/$USERNAME && \
     chmod 0440 /etc/sudoers.d/$USERNAME
 
+# Update nodejs version
+RUN apt-get update \
+    && apt install curl \
+    && curl -sL https://deb.nodesource.com/setup_12.x -o nodesource_setup.sh \
+  
 # Configure apt and install packages
 RUN apt-get update \
     &&  apt install -y ros-$ROS_DISTRO-rmw-fastrtps-cpp \
     &&  apt remove -y ros-$ROS_DISTRO-rmw-cyclonedds-cpp \
-    && apt-get -y install --no-install-recommends git nodejs npm libnss3-dev \
+    && apt-get -y install --no-install-recommends git nodejs libnss3-dev \
     libatk-adaptor libgtk2.0-0 libgtk-3-0 libgbm-dev libxss1 libasound2 wget \
     libx11* libxcb-dri*
 

--- a/dockerfile/visualizer/Dockerfile
+++ b/dockerfile/visualizer/Dockerfile
@@ -18,6 +18,7 @@ RUN groupadd --gid $USER_GID $USERNAME && \
 RUN apt-get update \
     && apt install curl \
     && curl -sL https://deb.nodesource.com/setup_12.x -o nodesource_setup.sh \
+    && bash nodesource_setup.sh
   
 # Configure apt and install packages
 RUN apt-get update \


### PR DESCRIPTION
node.js version problem occurred in [micro-ROS_crazyflie_demo/dockerfile/visualizer/Dockerfile](https://github.com/micro-ROS/micro-ROS_crazyflie_demo/blob/foxy/dockerfile/visualizer/Dockerfile) 

rclnodejs 0.20.0 requires node.js 10.23.1 or higher (and <13.0.0), `apt install nodejs` will only install 10.19.0 by default and will get a error like blow.

![node](https://user-images.githubusercontent.com/80691913/137616282-ed213328-0693-43bd-b45d-d4c38cc047dc.png)

So I added a process to install node.js 12. I also remove npm because it is included in node.js.

Feel free to change it if you have a better solution.
The following sites are for your reference.
https://www.digitalocean.com/community/tutorials/how-to-install-node-js-on-ubuntu-20-04